### PR TITLE
unescape csproj values

### DIFF
--- a/libs/parseCsproj.js
+++ b/libs/parseCsproj.js
@@ -64,7 +64,7 @@ module.exports = function() {
                   .map(item => {
                     let include = item.$.Include;
                     include = include.replace(/\\/g, path.sep); //normalize on *nix
-                    return include;
+                    return unescape(include);
                   })
                   .concat(fileIncludes);
 


### PR DESCRIPTION
VS likes to convert filenames that have special characters to be escaped with their hexadecimal value. For example, someone (not me of course) has added an image with parentheses to our project like `Aquinas College (MI).png` which appears in our csproj file as `Aquinas College %28MI%29.png`. This fix will unescape those file names prior to checking to see if they exist.